### PR TITLE
基于用户体验进行一些小修改

### DIFF
--- a/routes/course_routes.py
+++ b/routes/course_routes.py
@@ -89,11 +89,15 @@ def course_detail(course_id):
 
         review_count = Review.query.filter_by(course_teacher_id=ct.id).count()
         
+        # 将裸数组转换成对应的中文名称
+        semester_map = {'Fall': '秋', 'Spring': '春', 'Summer': '夏', 'Winter': '冬'}  # 季节转换映射
+        semester_str = ', '.join([f"{item.split()[0]}{semester_map[item.split()[1]]}" for item in semester_name])
+
         teachers_info.append({
             'teacher_id': ct.teacher.id, 
             'teacher_name': ct.teacher.name,
             'teacher_title': ct.teacher.title,
-            'semester_name': semester_name,
+            'semester_name': semester_str,
             'average_rating': average_rating,
             'review_count': review_count
         })

--- a/static/css/styles.css
+++ b/static/css/styles.css
@@ -646,6 +646,7 @@ a.btn, button.btn {
     border-radius: 5px;
     text-align: center;
     transition: box-shadow 0.3s ease;
+    user-select: none;
 }
 
 .course-card h3 {
@@ -1463,6 +1464,9 @@ a.btn, button.btn {
     font-size: 1rem;
     color: #666;
     margin-bottom: 0.5rem;
+    white-space: nowrap; 
+    overflow: hidden; 
+    text-overflow: ellipsis;
 }
 
 .course-actions {

--- a/templates/course_list.html
+++ b/templates/course_list.html
@@ -50,10 +50,10 @@
             <h3>{{ item.course.course_name }}</h3>
             <p class="course-code">{{ item.course.course_code }}</p>
             <p class="course-description"><strong>类型:</strong> {{ item.course.type }}</p>
-            <p><strong>教师:</strong> {{ item.teachers }}</p>
+            <p class="course-teacher" title="{{ item.teachers }}"><strong>教师:</strong> {{ item.teachers }}</p>
             <p><strong>学期:</strong> {{ item.semesters }}</p>
             <p><strong>评论数量:</strong> {{ item.review_count }}</p> <!-- 显示评论数量 -->
-            <a href="{{ url_for('course.course_detail', course_id=item.course.id) }}" class="btn view-details-btn">查看详情</a>
+            <a href="{{ url_for('course.course_detail', course_id=item.course.id) }}" class="btn view-details-btn" target="_blank">查看详情</a>
         </div>
         {% endfor %}
     </div>


### PR DESCRIPTION
基于我个人使用体验，修改了以下内容：

- 将课程教师选择界面原先的类似于`['2024 Fall', '2024 Spring']`进行了翻译，改为了`2024秋, 2024春`的格式。
- 将选择课程界面的查看详情按钮改为在新标签页打开。
- 修改选择课程界面的教师显示，默认只显示一行，当溢出的时候会使用`…`替代，当鼠标放到文字上的时候，会显示完整教师列表。同时将这部分文字修改为无法选择。